### PR TITLE
Wait for the 0x0D preamble

### DIFF
--- a/PowerMaxEsp8266/PowerMaxEsp8266.ino
+++ b/PowerMaxEsp8266/PowerMaxEsp8266.ino
@@ -428,7 +428,11 @@ bool serialHandler(PowerMaxAlarm* pm) {
   
   char oneByte = 0;  
   while (  (os_pmComPortRead(&oneByte, 1) == 1)  ) 
-  {     
+  {
+    // wait for the preamble
+    if (commandBuffer.size == 0 && oneByte != 0x0D)
+      continue;
+
     if (commandBuffer.size<(MAX_BUFFER_SIZE-1))
     {
       *(commandBuffer.size+commandBuffer.buffer) = oneByte;


### PR DESCRIPTION
Discard all data received from panel before the 0x0D message preamble.